### PR TITLE
Add some missing levels to accolades and clean up duplicate

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -10092,27 +10092,22 @@ let data = {
                             <li>Win 25 games with (primary/military/magic/support) towers</li>
                         </ul>
                     </ul>
-                `
-            },
-            "winsWithTower": {
-                "name": "Wins with a tower",
-                "data": `
-                    <ul>
-                        <li>Level 1</li>
-                        <ul>
-                            <li>Win 50 games with (x) tower</li>
-                        </ul>
-                    </ul>
-                    <ul>
+		    <ul>
                         <li>Level 2</li>
                         <ul>
-                            <li>Win 250 games with (x) tower</li>
+                            <li>Win 50 games with (primary/military/magic/support) towers</li>
                         </ul>
                     </ul>
-                    <ul>
+		    <ul>
                         <li>Level 3</li>
                         <ul>
-                            <li>Win 500 games with (x) tower</li>
+                            <li>Win 250 games with (primary/military/magic/support) towers</li>
+                        </ul>
+                    </ul>
+		    <ul>
+                        <li>Level 4</li>
+                        <ul>
+                            <li>Win 500 games with (primary/military/magic/support) towers</li>
                         </ul>
                     </ul>
                 `
@@ -10149,6 +10144,12 @@ let data = {
                             <li>Complete (event) 3 times</li>
                         </ul>
                     </ul>
+		    <ul>
+                        <li>Level 2</li>
+                        <ul>
+                            <li>Complete (event) 10 times</li>
+                        </ul>
+                    </ul>
                 `
             },
             "winEventGames": {
@@ -10172,6 +10173,12 @@ let data = {
                             <li>Win a total of 500 (event) games</li>
                         </ul>
                     </ul>
+		    <ul>
+                        <li>Level 3</li>
+                        <ul>
+                            <li>Win a total of 1000 (event) games</li>
+                        </ul>
+                    </ul>
                 `
             },
             "collectFromBananaFarms": {
@@ -10193,6 +10200,12 @@ let data = {
                         <li>Level 3</li>
                         <ul>
                             <li>Collect $100,000,000 from banana farms</li>
+                        </ul>
+                    </ul>
+		    <ul>
+                        <li>Level 4</li>
+                        <ul>
+                            <li>Collect $1,000,000,000 from banana farms</li>
                         </ul>
                     </ul>
                 `
@@ -10344,22 +10357,28 @@ let data = {
             "winGamesWithTower": {
                 "name": "Win games with a tower",
                 "data": `
-                    <ul>
+		    <ul>
                         <li>Level 1</li>
                         <ul>
-                            <li>Win a total of 100 games with (tower)</li>
+                            <li>Win 50 games with (x) tower</li>
                         </ul>
                     </ul>
                     <ul>
                         <li>Level 2</li>
                         <ul>
-                            <li>Win a total of 500 games with (hero)</li>
+                            <li>Win 250 games with (x) tower</li>
                         </ul>
                     </ul>
                     <ul>
                         <li>Level 3</li>
                         <ul>
-                            <li>Win a total of 1000 games with (hero)</li>
+                            <li>Win 500 games with (x) tower</li>
+                        </ul>
+                    </ul>
+		    <ul>
+                        <li>Level 4</li>
+                        <ul>
+                            <li>Win 1000 games with (x) tower</li>
                         </ul>
                     </ul>
                 `
@@ -10558,6 +10577,12 @@ let data = {
                             <li>Win 500 casual games</li>
                         </ul>
                     </ul>
+		    <ul>
+                        <li>Level 4</li>
+                        <ul>
+                            <li>Win 1000 casual games</li>
+                        </ul>
+                    </ul>
                 `
             },
             "winRankedGames": {
@@ -10703,7 +10728,7 @@ let data = {
                         </ul>
                     </ul>
                 `
-            }
+	    }
         }
     },
     "bloons": {


### PR DESCRIPTION
- Copied "Wins with a tower" data into to "Win games with a tower" then removed it, added level 4
- Added levels for "Win with a tower category"
- Added level 2 for "Complete Events"
- Added level 4 for "Win Event Games", "Win Casual Games", and "Collect Money From Farms"